### PR TITLE
feat: Header 로그아웃 상태의 Header 구현

### DIFF
--- a/src/app/(auth)/signin/page.tsx
+++ b/src/app/(auth)/signin/page.tsx
@@ -1,0 +1,5 @@
+function SignIn() {
+  return <div>로그인</div>;
+}
+
+export default SignIn;

--- a/src/app/(auth)/signup/page.tsx
+++ b/src/app/(auth)/signup/page.tsx
@@ -1,0 +1,5 @@
+function SignUp() {
+  return <div>회원가입</div>;
+}
+
+export default SignUp;

--- a/src/app/_components/Header.tsx
+++ b/src/app/_components/Header.tsx
@@ -11,7 +11,7 @@ function Header() {
 
   return (
     <div className="sticky top-0 z-10 bg-white">
-      <div className="mx-auto flex max-w-[1224px] items-center justify-between">
+      <div className="mx-auto flex max-w-[1224px] items-center justify-between px-6">
         <Link href="/">
           <Image src="/images/logo_small.png" alt="헤더 로고" width={165} height={55} priority />
         </Link>

--- a/src/app/_components/Header.tsx
+++ b/src/app/_components/Header.tsx
@@ -1,0 +1,27 @@
+"use client";
+
+import Image from "next/image";
+import Link from "next/link";
+import { useSelectedLayoutSegment } from "next/navigation";
+
+function Header() {
+  const segment = useSelectedLayoutSegment();
+
+  if (segment === "(auth)") return <div />;
+
+  return (
+    <div className="sticky top-0 z-10 bg-white">
+      <div className="mx-auto flex max-w-[1224px] items-center justify-between">
+        <Link href="/">
+          <Image src="/images/logo_small.png" alt="헤더 로고" width={165} height={55} priority />
+        </Link>
+        <div className="flex items-center justify-center gap-6 text-sm font-medium">
+          <Link href="/signin">로그인</Link>
+          <Link href="/signup">회원가입</Link>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default Header;

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,3 +1,4 @@
+import Header from "@/app/_components/Header";
 import type { Metadata } from "next";
 import { Inter } from "next/font/google";
 
@@ -17,7 +18,10 @@ function RootLayout({
 }>) {
   return (
     <html lang="en">
-      <body className={inter.className}>{children}</body>
+      <body className={`${inter.className} text-black`}>
+        <Header />
+        {children}
+      </body>
     </html>
   );
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

> ST-35-Header

## 📝작업 내용

> - 루트 layout.tsx에서 전체 폰트 색깔이 #1b1b1b라 classname으로 넣어줬습니다.
> - 로그인, 회원 가입 페이지 url만 구현했습니다. => 원활한 Link 이동 기능 구현을 위해서
> - 유저상태를 알 방법이 없어서 로그아웃 기준의 Header를 구현했습니다.

### 스크린샷 (선택)
https://github.com/user-attachments/assets/6afbab22-9022-4e32-b7f2-3e1b7415871f

## 💬리뷰 요구사항(선택)

> 지금 pr 쓴 양식 괜찮나요?? 
> 추후에 유저 상태와 드랍다운 컴포넌트가 완성되면 완벽하게 헤더를 완성시켜보겠습니다.