### PR TITLE
feat: Button 컴포넌트 구현

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -52,7 +52,8 @@
           "some": ["nesting", "id"]
         }
       }
-    ]
+    ],
+    "react/require-default-props": "off"
   },
   "settings": {
     "react": {

--- a/src/app/_components/Button.tsx
+++ b/src/app/_components/Button.tsx
@@ -1,0 +1,55 @@
+"use client";
+
+import Link from "next/link";
+
+interface Props extends React.PropsWithChildren {
+  href?: string;
+  variant?: keyof typeof buttonStyleByVariant;
+  size?: keyof typeof buttonStyleBySize;
+  disabled?: boolean;
+  onClick?: () => void;
+}
+
+const buttonStyleByVariant = {
+  default: "bg-green text-white disabled:bg-gray-600",
+  outline:
+    "border border-green bg-white text-green disabled:border-none disabled:bg-gray-600 disabled:text-white",
+};
+
+const buttonStyleBySize = {
+  wide: "h-[56px] text-base",
+  large: "h-[56px] max-w-[136px] text-base",
+  medium: "h-[48px] max-w-[120px] text-base",
+  small: "h-[38px] max-w-20 text-sm",
+};
+
+export default function Button({
+  href,
+  variant = "default",
+  size = "medium",
+  disabled = false,
+  onClick,
+  children,
+}: Props) {
+  if (href) {
+    return (
+      <Link
+        className={`${buttonStyleBySize[size]} ${disabled ? "cursor-default bg-gray-600 text-white" : buttonStyleByVariant[variant]} inline-flex w-full items-center justify-center rounded-lg font-semibold`}
+        href={disabled ? "/" : href}
+      >
+        {children}
+      </Link>
+    );
+  }
+
+  return (
+    <button
+      className={`${buttonStyleBySize[size]} ${buttonStyleByVariant[variant]} w-full rounded-lg font-semibold`}
+      disabled={disabled}
+      onClick={onClick}
+      type="submit"
+    >
+      {children}
+    </button>
+  );
+}

--- a/src/app/_components/Button.tsx
+++ b/src/app/_components/Button.tsx
@@ -31,10 +31,10 @@ export default function Button({
   onClick,
   children,
 }: Props) {
-  if (href) {
+  if (href && !disabled) {
     return (
       <Link
-        className={`${buttonStyleBySize[size]} ${disabled ? "cursor-default bg-gray-600 text-white" : buttonStyleByVariant[variant]} inline-flex w-full items-center justify-center rounded-lg font-semibold`}
+        className={`${buttonStyleBySize[size]} ${buttonStyleByVariant[variant]} inline-flex w-full items-center justify-center rounded-lg font-semibold`}
         href={disabled ? "/" : href}
       >
         {children}


### PR DESCRIPTION
## #️⃣연관된 이슈

ST-12-Button

## 📝작업 내용

```tsx
// 링크로 사용할 때
<Button href="/login" varient="outline" size="wide" disabled>로그인</Button>

// 버튼으로 사용할 때
<Button onClick={clilckHandler} varient="outline" size="wide" disabled>검색</Button>
```

Button 컴포넌트 내부에서 href 유무에 따라 Link 컴포넌트 혹은 button 태그를 반환합니다.

피그마 시안대로 만들긴 했는데 너무 커다랗네요.
스타일은 나중에 수정될 것 같아요.

버튼 스타일이 통일될 수 있도록 Button에서 varient, size에 따라서 다른 스타일을 적용합니다.

### 스크린샷

![image](https://github.com/user-attachments/assets/be68e47f-eb12-4e33-b486-c3160427a590)

## 💬리뷰 요구사항

만들면서 느낀 건데 이렇게 만들 경우 Link 컴포넌트의 기본적인 props들과 button 태그이 기본적인 props들을 모두 응용하는데 무리가 있습니다.
그러려면 Link 컴포넌트와 button 태그의 모든 props들을 받아와서 href 유무에 따라서 다른 props들을 가지도록 하면 되는데요.
구현할 수는 있습니다.

근데 그렇게 하면 타입 추론이 조금 힘들어져요.
그리고 Link 컴포넌트의 특성 상 disabled 속성을 사용할 일이 없어서 불필요한 prop을 전달해주는 기분이 듭니다. (링크 이동시켜주는 버튼이므로 disabled할 일이 없을 것 같음)

그래서 그냥 Link 버튼이랑 그냥 버튼을 나누고 싶은 마음이 생겼어요 ㅋㅋ

의견 부탁드려요.

